### PR TITLE
Support angle brackets in function names

### DIFF
--- a/dispatch/sdk/v1/call.proto
+++ b/dispatch/sdk/v1/call.proto
@@ -27,7 +27,7 @@ message Call {
   // received by the function service when the asynchronous call is made.
   string function = 3 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.pattern = "^[a-zA-Z_][a-zA-Z0-9_]*$"
+    (buf.validate.field).string.pattern = "^[a-zA-Z_][a-zA-Z0-9_<>]*$"
   ];
 
   // Arguments to the coroutine.

--- a/dispatch/sdk/v1/call.proto
+++ b/dispatch/sdk/v1/call.proto
@@ -27,7 +27,7 @@ message Call {
   // received by the function service when the asynchronous call is made.
   string function = 3 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.pattern = "^[a-zA-Z_][a-zA-Z0-9_<>]*$"
+    (buf.validate.field).string.pattern = "^[a-zA-Z_][a-zA-Z0-9_<>.]*$"
   ];
 
   // Arguments to the coroutine.


### PR DESCRIPTION
Python functions can have angle brackets in their names, for example when defined inside another function. For example:

    run.<locals>.hello_world_async