### PR TITLE
Add fields that let clients reconstruct the call hierarchy

### DIFF
--- a/dispatch/sdk/v1/call.proto
+++ b/dispatch/sdk/v1/call.proto
@@ -57,4 +57,7 @@ message CallResult {
   // It is valid to have both an output and an error, in which case the output
   // might contain a partial result.
   Error error = 3;
+
+  // Opaque identifier for the function call.
+  string dispatch_id = 4;
 }

--- a/dispatch/sdk/v1/function.proto
+++ b/dispatch/sdk/v1/function.proto
@@ -47,6 +47,21 @@ message RunRequest {
   // It's the same value as the Dispatch ID that was returned when the call
   // was dispatched (on DispatchResponse).
   string dispatch_id = 4;
+
+  // Opaque identifier for the parent function call.
+  //
+  // Functions can call other functions via Poll.calls. If this function call
+  // has a parent function call, the identifier of the parent can be found
+  // here. If the function call does not have a parent, the field will
+  // be empty.
+  string parent_dispatch_id = 5;
+
+  // Opaque identifier for the root function call.
+  //
+  // When functions call other functions, an additional level on the call
+  // hierarchy tree is created. This field carries the identifier of the
+  // root function call in the tree.
+  string root_dispatch_id = 6;
 }
 
 // RunResponse is returned by calls to the Run method of FunctionService.


### PR DESCRIPTION
In https://github.com/stealthrocket/dispatch-proto/pull/24 we added `RunRequest.dispatch_id`, to allow clients to link requests back to a particular call dispatch.

When a function calls other functions via `Poll`, clients have no way to link the children back to their parent calls. 

This PR adds additional fields that allow clients to reconstruct the call hierarchy as requests are handled.

I've explicitly left out a `PollResult.dispatch_ids`, so that there's no confusion between the usage of these identifiers vs. the correlation IDs that users currently use to link call results back to their original calls.