### PR TITLE
Add function_version to Call

### DIFF
--- a/dispatch/sdk/v1/call.proto
+++ b/dispatch/sdk/v1/call.proto
@@ -40,9 +40,9 @@ message Call {
   // The value might be capped to a maximum by the service handling the call.
   google.protobuf.Duration expiration = 5 [(buf.validate.field).duration.gte = {seconds: 0}];
 
-  // Version of the function to select during execution.
+  // Version of the application to select during execution.
   // The version is an optional field and not supported by all execution platforms.
-  string function_version = 6;
+  string version = 6;
 }
 
 // CallResult is the result of a call operation.


### PR DESCRIPTION
This changes add a function_version field to the Call data model to allow selecting the right version of the code during execution.